### PR TITLE
CDK deployment of Docker container on Fargate

### DIFF
--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,10 @@
+*.swp
+package-lock.json
+__pycache__
+.pytest_cache
+.venv
+*.egg-info
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,38 @@
+# Webapp Infrastructure
+
+Learning from [this](https://aws.amazon.com/blogs/containers/create-a-ci-cd-pipeline-for-amazon-ecs-with-github-actions-and-aws-codebuild-tests/) article
+and intending on creating a very minimal CI/CD environment using ECR Fargate, deployed with
+the AWS CDK.
+
+# Installation and Setup
+
+Install CDK:
+
+`pip install aws-cdk-lib`
+
+Make sure your AWS environment works:
+
+`aws s3 ls`
+
+Install dependencies:
+
+`pip install -r requirements.txt`
+
+# Deploy
+
+Set up the initial CDK environment:
+
+`cdk bootstrap`
+
+and then create the environment:
+
+`cdk deploy`
+
+
+## Useful commands
+
+ * `cdk ls`          list all stacks in the app
+ * `cdk synth`       emits the synthesized CloudFormation template
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk docs`        open CDK documentation

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -8,7 +8,7 @@ from infrastructure.infrastructure_stack import InfrastructureStack
 app = cdk.App()
 InfrastructureStack(
     app,
-    "InfrastructureStack",
+    "FOSS4G2023Stack",
     env=cdk.Environment(account="760327784017", region="ap-southeast-2"),
 )
 

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+import aws_cdk as cdk
+
+from infrastructure.infrastructure_stack import InfrastructureStack
+
+
+app = cdk.App()
+InfrastructureStack(
+    app,
+    "InfrastructureStack",
+    env=cdk.Environment(account="760327784017", region="ap-southeast-2"),
+)
+
+app.synth()

--- a/infrastructure/cdk.context.json
+++ b/infrastructure/cdk.context.json
@@ -1,0 +1,11 @@
+{
+  "availability-zones:account=760327784017:region=ap-southeast-2": [
+    "ap-southeast-2a",
+    "ap-southeast-2b",
+    "ap-southeast-2c"
+  ],
+  "hosted-zone:account=760327784017:domainName=foss4g-oceania.org:region=ap-southeast-2": {
+    "Id": "/hostedzone/Z46DX5986TP2Y",
+    "Name": "foss4g-oceania.org."
+  }
+}

--- a/infrastructure/cdk.json
+++ b/infrastructure/cdk.json
@@ -1,0 +1,49 @@
+{
+  "app": "python3 app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true
+  }
+}

--- a/infrastructure/infrastructure/infrastructure_stack.py
+++ b/infrastructure/infrastructure/infrastructure_stack.py
@@ -1,0 +1,42 @@
+from aws_cdk import (
+    Stack,
+    aws_ec2 as ec2,
+    aws_ecs as ecs,
+    aws_route53 as route53,
+    aws_ecs_patterns as ecs_patterns,
+    aws_elasticloadbalancingv2 as elbv2,
+)
+
+from constructs import Construct
+
+
+class InfrastructureStack(Stack):
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        vpc = ec2.Vpc(self, "foss4g-2023-VPC")  # default is all AZs in region
+
+        cluster = ecs.Cluster(self, "foss4g-2023-Cluster", vpc=vpc)
+
+        zone = route53.HostedZone.from_lookup(
+            self, "foss4g-oceania-zone", domain_name="foss4g-oceania.org"
+        )
+
+        ecs_patterns.ApplicationLoadBalancedFargateService(
+            self,
+            "foss4g-2023-Service",
+            cluster=cluster,
+            cpu=512,
+            desired_count=1,
+            task_image_options=ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
+                image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")
+            ),
+            memory_limit_mib=1024,
+            public_load_balancer=True,
+            domain_name="2023.foss4g-oceania.org",
+            domain_zone=zone,
+            redirect_http=True,
+            protocol=elbv2.ApplicationProtocol.HTTPS
+        )
+
+        # TODO: Set up a DB, probably a bucket for media/assets too

--- a/infrastructure/infrastructure/infrastructure_stack.py
+++ b/infrastructure/infrastructure/infrastructure_stack.py
@@ -5,6 +5,10 @@ from aws_cdk import (
     aws_route53 as route53,
     aws_ecs_patterns as ecs_patterns,
     aws_elasticloadbalancingv2 as elbv2,
+    aws_rds as rds,
+    aws_s3 as s3,
+    aws_ecr as ecr,
+    aws_secretsmanager as secretsmanager
 )
 
 from constructs import Construct
@@ -14,12 +18,24 @@ class InfrastructureStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        vpc = ec2.Vpc(self, "foss4g-2023-VPC")  # default is all AZs in region
+        vpc = ec2.Vpc(self, "foss4g-2023-VPC", nat_gateways=1, max_azs=2)
 
         cluster = ecs.Cluster(self, "foss4g-2023-Cluster", vpc=vpc)
 
         zone = route53.HostedZone.from_lookup(
             self, "foss4g-oceania-zone", domain_name="foss4g-oceania.org"
+        )
+
+        db_secret = rds.DatabaseSecret(
+            self,
+            "password",
+            username="foss4g",
+        )
+
+        image_repo = ecr.Repository(
+            self,
+            "foss4g-2023-Repo",
+            repository_name="foss4g-sotm-oceania-2023"
         )
 
         ecs_patterns.ApplicationLoadBalancedFargateService(
@@ -29,7 +45,12 @@ class InfrastructureStack(Stack):
             cpu=512,
             desired_count=1,
             task_image_options=ecs_patterns.ApplicationLoadBalancedTaskImageOptions(
-                image=ecs.ContainerImage.from_registry("amazon/amazon-ecs-sample")
+                image=ecs.ContainerImage.from_ecr_repository(image_repo, "latest"),
+                secrets={
+                    "DB_HOSTNAME": ecs.Secret.from_secrets_manager(db_secret, "host"),
+                    "DB_USERNAME": ecs.Secret.from_secrets_manager(db_secret, "username")
+                },
+                container_port=80
             ),
             memory_limit_mib=1024,
             public_load_balancer=True,
@@ -39,4 +60,21 @@ class InfrastructureStack(Stack):
             protocol=elbv2.ApplicationProtocol.HTTPS
         )
 
-        # TODO: Set up a DB, probably a bucket for media/assets too
+        rds.DatabaseInstance(
+            self,
+            "foss4g-2023-db",
+            instance_type=ec2.InstanceType("t4g.micro"),
+            database_name="foss4g",
+            engine=rds.DatabaseInstanceEngine.POSTGRES,
+            credentials=rds.Credentials.from_secret(db_secret),
+            vpc=vpc,
+        )
+
+        # Bucket
+        s3.Bucket(
+            self,
+            "foss4g-2023-public",
+            bucket_name="foss4g-2023-public",
+            public_read_access=True,
+            access_control=s3.BucketAccessControl.PUBLIC_READ,
+        )

--- a/infrastructure/requirements.txt
+++ b/infrastructure/requirements.txt
@@ -1,0 +1,2 @@
+aws-cdk-lib==2.74.0
+constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
This PR adds a CDK deployment of a generic container to AWS's Fargate.

It's a bit expensive, because of the application load balancer, but I think it's quite good and flexible.

What we need to do next is:

1. Get a Docker image for the Django app going
2. Make sure we can get [static files being stored on s3](https://testdriven.io/blog/storing-django-static-and-media-files-on-amazon-s3/)
3. Set up CI/CD to build, push and update the image.

Oh, and build the actual web app!